### PR TITLE
неверные значения при отмене результата изменения значения в меню

### DIFF
--- a/fan_control_with_display.ino
+++ b/fan_control_with_display.ino
@@ -150,20 +150,38 @@ void setup()
 	//-------------------------
 	// считывание настроек из eeprom
 	Serial.println(F("SETUP loading params from eeprom"));
+
 	uint8_t v = eepromGetDelayBeforeFanOnValue();
 	if (isDelayBeforeFanOnValueValid(v))
 	{
 		cfgDelayBeforeFanOn = v;
 	}
+	else
+	{
+		// невалидное значение в eeprom - переписать дефолтным
+		eepromSaveDelayBeforeFanOnValue(cfgDelayBeforeFanOn);
+	}
+
 	v = eepromGetFanWorkTimeValue();
 	if (isFanWorkTimeValueValid(v))
 	{
 		cfgFanWorkTimeMinutes = v;
 	}
+	else
+	{
+		// невалидное значение в eeprom - переписать дефолтным
+		eepromSaveFanWorkTimeValue(cfgFanWorkTimeMinutes);
+	}
+
 	v = eepromGetFanOnSensorValue();
 	if (isFanOnSensorLevelValueValid(v))
 	{
 		cfgFanOnSensorLevel = v;
+	}
+	else
+	{
+		// невалидное значение в eeprom - переписать дефолтным
+		eepromSaveFanOnSensorValue(cfgFanOnSensorLevel);
 	}
 	// -------------------------
 


### PR DESCRIPTION
Это проявляется при первом запуске.

Ибо в eeprom все забито как 0xff.

Добавлена установка в eeprom значения на  текущее в setup(), если значение невалидное. 